### PR TITLE
Remove 'use 5.14' line from tests

### DIFF
--- a/t/base_resolution.t
+++ b/t/base_resolution.t
@@ -1,6 +1,5 @@
 #!/usr/bin/perl
 
-use v5.14;
 use strict;
 use warnings;
 no warnings 'redefine';

--- a/t/rel.t
+++ b/t/rel.t
@@ -1,6 +1,5 @@
 #!/usr/bin/perl
 
-use v5.14;
 use strict;
 use warnings;
 no warnings 'redefine';


### PR DESCRIPTION
use 5.14 in tests results in module only being installable with 'notest' or carton, see issue #17 